### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,7 +11,7 @@ spaCy: Industrial-strength NLP
 I wrote it because I think small companies are terrible at NLP.  Or rather:
 small companies are using terrible NLP technology.
 
-.. spaCy:: https://github.com/honnibal/spaCy/
+.. _spaCy: https://github.com/honnibal/spaCy/
 
 To do great NLP, you have to know a little about linguistics, a lot
 about machine learning, and almost everything about the latest research.
@@ -58,7 +58,7 @@ spaCy provides a library of utility functions that help programmers build such
 products.  It's commercial open source software: you can either use it under
 the AGPL, or you can `buy a commercial license`_ for a one-time fee. 
 
-.. _buy a commercial license: license.rst
+.. _buy a commercial license: license.html
 
 Example functionality
 ---------------------


### PR DESCRIPTION
Fix two broken links.

Couldn't find link to repo in the [docs](http://honnibal.github.io/spaCy/) => went to check the source, found the sciPy link at the top didn't render.

Similarly, the link to commercial license lead to http://honnibal.github.io/spaCy/license.rst which is a 404.