### PR TITLE
docs: Added missing cosine declaration

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -207,6 +207,7 @@ problematic, given our starting assumptions:
     >>> from numpy.linalg import norm
     >>> import spacy.en
     >>> from spacy.postags import ADVERB, VERB
+    >>> cosine = lambda v1, v2: dot(v1, v2) / (norm(v1), norm(v2))
     >>> def is_bad_adverb(token, target_verb, tol):
     ...   if token.pos != ADVERB 
     ...     return False


### PR DESCRIPTION
* Added missing cosine declaration to code listing that already included
  imports for `dot` and `norm` function it uses.

Signed-off-by: mr.Shu <mr@shu.io>


----------------------------------------------------

@honnibal Thanks a ton for a great library! 

While reading the index document I kind of skipped the previous declarations of `cosine`. It seemed strange not to find them here since the imports were already in place.