### PR TITLE
docs: Change `postags` to `parts_of_speech`

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -184,7 +184,7 @@ adverbs to.  Recall that our previous adverb highlighting function looked like
 this:
 
     >>> import spacy.en
-    >>> from spacy.postags import ADVERB
+    >>> from spacy.parts_of_speech import ADVERB
     >>> # Load the pipeline, and call it with some text.
     >>> nlp = spacy.en.English()
     >>> tokens = nlp("‘Give it back,’ he pleaded abjectly, ‘it’s mine.’",
@@ -206,7 +206,7 @@ problematic, given our starting assumptions:
     >>> from numpy import dot
     >>> from numpy.linalg import norm
     >>> import spacy.en
-    >>> from spacy.postags import ADVERB, VERB
+    >>> from spacy.parts_of_speech import ADVERB, VERB
     >>> def is_bad_adverb(token, target_verb, tol):
     ...   if token.pos != ADVERB 
     ...     return False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -184,14 +184,14 @@ adverbs to.  Recall that our previous adverb highlighting function looked like
 this:
 
     >>> import spacy.en
-    >>> from spacy.parts_of_speech import ADVERB
+    >>> from spacy.parts_of_speech import ADV
     >>> # Load the pipeline, and call it with some text.
     >>> nlp = spacy.en.English()
     >>> tokens = nlp("‘Give it back,’ he pleaded abjectly, ‘it’s mine.’",
                      tag=True, parse=True)
     >>> output = ''
     >>> for tok in tokens:
-    ...     output += tok.string.upper() if tok.pos == ADVERB else tok.string
+    ...     output += tok.string.upper() if tok.pos == ADV else tok.string
     ...     output += tok.whitespace
     >>> print(output)
     ‘Give it BACK,’ he pleaded ABJECTLY, ‘it’s mine.’
@@ -206,9 +206,9 @@ problematic, given our starting assumptions:
     >>> from numpy import dot
     >>> from numpy.linalg import norm
     >>> import spacy.en
-    >>> from spacy.parts_of_speech import ADVERB, VERB
+    >>> from spacy.parts_of_speech import ADV, VERB
     >>> def is_bad_adverb(token, target_verb, tol):
-    ...   if token.pos != ADVERB 
+    ...   if token.pos != ADV
     ...     return False
     ...   elif toke.head.pos != VERB:
     ...     return False


### PR DESCRIPTION
* It seems that the docs use `spacy.postags` but the actual module that
  can be found in `spacy/` is `parts_of_speech`.

Signed-off-by: mr.Shu <mr@shu.io>

---------------------

@honnibal I am sorry if you would like to move `parts_of_speech` to `postags` but the sample code in `index.rst` was not working for me. These changes make it functional.