### PR TITLE
Changing deprecated codecs.open to io.open

### DIFF
--- a/bin/init_model.py
+++ b/bin/init_model.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from shutil import copyfile
 from shutil import copytree
-import codecs
+import io
 
 from spacy.en import get_lex_props
 from spacy.vocab import Vocab
@@ -41,7 +41,7 @@ def setup_tokenizer(lang_data_dir, tok_dir):
 
 def _read_clusters(loc):
     clusters = {}
-    for line in codecs.open(str(loc), 'r', 'utf8'):
+    for line in io.open(str(loc), 'r', encoding='utf8'):
         try:
             cluster, word, freq = line.split()
         except ValueError:
@@ -65,7 +65,7 @@ def _read_clusters(loc):
 
 def _read_probs(loc):
     probs = {}
-    for i, line in enumerate(codecs.open(str(loc), 'r', 'utf8')):
+    for i, line in enumerate(io.open(str(loc), 'r', encoding='utf8')):
         prob, word = line.split()
         prob = float(prob)
         probs[word] = prob

--- a/bin/ner_tag.py
+++ b/bin/ner_tag.py
@@ -1,11 +1,11 @@
-import codecs
+import io
 import plac
 
 from spacy.en import English
 
 
 def main(text_loc):
-    with codecs.open(text_loc, 'r', 'utf8') as file_:
+    with io.open(text_loc, 'r', encoding='utf8') as file_:
         text = file_.read()
     NLU = English()
     for paragraph in text.split('\n\n'):

--- a/bin/parser/train.py
+++ b/bin/parser/train.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import os
 from os import path
 import shutil
-import codecs
+import io
 import random
 
 import plac
@@ -169,7 +169,7 @@ def write_parses(Language, dev_loc, model_dir, out_loc):
     nlp = Language()
     gold_tuples = read_docparse_file(dev_loc)
     scorer = Scorer()
-    out_file = codecs.open(out_loc, 'w', 'utf8')
+    out_file = io.open(out_loc, 'w', encoding='utf8')
     for raw_text, segmented_text, annot_tuples in gold_tuples:
         tokens = nlp(raw_text)
         for t in tokens:

--- a/bin/prepare_treebank.py
+++ b/bin/prepare_treebank.py
@@ -27,7 +27,7 @@ import json
 from os import path
 import os
 import re
-import codecs
+import io
 from collections import defaultdict
 
 from spacy.munge import read_ptb
@@ -122,7 +122,7 @@ def read_file(*pieces):
     if not path.exists(loc):
         return None
     else:
-        return codecs.open(loc, 'r', 'utf8').read().strip()
+        return io.open(loc, 'r', encoding='utf8').read().strip()
 
 
 def get_file_names(section_dir, subsection):

--- a/spacy/en/lemmatizer.py
+++ b/spacy/en/lemmatizer.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from os import path
-import codecs
+import io
 
 
 NOUN_RULES = (
@@ -85,7 +85,7 @@ def lemmatize(string, index, exceptions, rules):
 
 def read_index(loc):
     index = set()
-    for line in codecs.open(loc, 'r', 'utf8'):
+    for line in io.open(loc, 'r', encoding='utf8'):
         if line.startswith(' '):
             continue
         pieces = line.split()
@@ -97,7 +97,7 @@ def read_index(loc):
 
 def read_exc(loc):
     exceptions = {}
-    for line in codecs.open(loc, 'r', 'utf8'):
+    for line in io.open(loc, 'r', encoding='utf8'):
         if line.startswith(' '):
             continue
         pieces = line.split()

--- a/spacy/gold.pyx
+++ b/spacy/gold.pyx
@@ -1,5 +1,5 @@
 import numpy
-import codecs
+import io
 import json
 import ujson
 import random

--- a/spacy/strings.pyx
+++ b/spacy/strings.pyx
@@ -1,4 +1,4 @@
-import codecs
+import io
 
 from libc.string cimport memcpy
 from murmurhash.mrmr cimport hash64
@@ -112,11 +112,11 @@ cdef class StringStore:
             string = &self.strings[i]
             py_string = string.chars[:string.length]
             strings.append(py_string.decode('utf8'))
-        with codecs.open(loc, 'w', 'utf8') as file_:
+        with io.open(loc, 'w', encoding='utf8') as file_:
             file_.write(SEPARATOR.join(strings))
 
     def load(self, loc):
-        with codecs.open(loc, 'r', 'utf8') as file_:
+        with io.open(loc, 'r', encoding='utf8') as file_:
             strings = file_.read().split(SEPARATOR)
         cdef unicode string
         cdef bytes byte_string

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -1,5 +1,5 @@
 from os import path
-import codecs
+import io
 import json
 import re
 
@@ -7,7 +7,7 @@ DATA_DIR = path.join(path.dirname(__file__), '..', 'data')
 
 
 def utf8open(loc, mode='r'):
-    return codecs.open(loc, mode, 'utf8')
+    return io.open(loc, mode, encoding='utf8')
 
 
 def read_lang_data(data_dir):

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -4,7 +4,7 @@ from libc.stdint cimport int32_t
 
 import bz2
 from os import path
-import codecs
+import io
 import math
 
 from .lexeme cimport EMPTY_LEXEME

--- a/tests/test_parse_navigate.py
+++ b/tests/test_parse_navigate.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from os import path
-import codecs
+import io
 
 from spacy.en import English
 
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.fixture
 def sun_text():
-    with codecs.open(path.join(path.dirname(__file__), 'sun.txt'), 'r', 'utf8') as file_:
+    with io.open(path.join(path.dirname(__file__), 'sun.txt'), 'r', encoding='utf8') as file_:
         text = file_.read()
     return text
 


### PR DESCRIPTION
@honnibal I am looking for `goodfirstbug` to fix in spaCy as I am picking cython and reading Kurt Smith's book. I caught the deprecated `codecs.open` from the .py code. But if there are any other `goodfirstbug` to fix, esp. from the .pyx code, I will be glad to help out.

P/S: Also, it's great to see that @nltk is replacing the outdated maxent tagger with your perceptron tagger.