### PR TITLE
Fix docs to match code (like_number)

### DIFF
--- a/website/src/jade/docs/_api.html
+++ b/website/src/jade/docs/_api.html
@@ -246,7 +246,7 @@ array([[11880],
       </li>
       <li><span class="declaration"><code>like_url</code></span> Does the word resembles a URL?
       </li>
-      <li><span class="declaration"><code>like_num</code></span> Does the word represent a number? e.g. “10.9”, “10”, “ten”, etc
+      <li><span class="declaration"><code>like_number</code></span> Does the word represent a number? e.g. “10.9”, “10”, “ten”, etc
       </li>
       <li><span class="declaration"><code>like_email</code></span> Does the word resemble an email?
       </li>

--- a/website/src/jade/docs/_api.jade
+++ b/website/src/jade/docs/_api.jade
@@ -118,7 +118,7 @@ mixin LexemeBooleans()
             |  Equivalent to #[code.language-python word.orth_.isspace()]
         +Define("like_url")
             |  Does the word resembles a URL?
-        +Define("like_num")
+        +Define("like_number")
             |  Does the word represent a number? e.g. “10.9”, “10”, “ten”, etc
         +Define("like_email")
             |  Does the word resemble an email?


### PR DESCRIPTION
s/like_num/like_number

It should match language.py.

Also, `is_oov()` is not actually accessible yet, is it?

If it is implemented, then I can add it to language.py.  Otherwise I can rm it from the docs in this PR.
