### PR TITLE
add __repr__  print text default for doc, token, and span

### DIFF
--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -120,6 +120,9 @@ cdef class Doc:
     def __str__(self):
         return u''.join([t.string for t in self])
 
+    def __repr__(self):
+        return u''.join([t.string for t in self])
+
     def similarity(self, other):
         if self.vector_norm == 0 or other.vector_norm == 0:
             return 0.0

--- a/spacy/tokens/spans.pyx
+++ b/spacy/tokens/spans.pyx
@@ -46,6 +46,12 @@ cdef class Span:
             return 0
         return self.end - self.start
 
+    def __repr__(self):
+        text = self.text_with_ws
+        if self[-1].whitespace_:
+            text = text[:-1]
+        return text
+
     def __getitem__(self, object i):
         if isinstance(i, slice):
             start, end = normalize_slice(len(self), i.start, i.stop, i.step)

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -43,6 +43,9 @@ cdef class Token:
     def __str__(self):
         return self.string
 
+    def __repr__(self):
+        return self.string
+
     cpdef bint check_flag(self, attr_id_t flag_id) except -1:
         return Lexeme.c_check_flag(self.c.lex, flag_id)
 


### PR DESCRIPTION
Not sure this is a feature everyone needs - I usually play around a lot in ipython when working with a new library, so I made these simple changes clearly for fast visualization purposes based on what str and unicode returned for each of the text representation classes. Text just seems like a reasonable default - it's better than printing an id string for the class.

Example usage from within ipython
```python
>> from spacy.en import English
>> nlp = English()
>> doc = nlp(u'Craig Robinson was denied a sentence. '
              'At least so it seemed until Lara Croft came along')
>> doc[0]
Craig
>> doc[0:5]
Craig Robinson was denied a
>> doc.ents
(Craig Robinson, Lara Croft)
>> for sent in doc.sents:
>>     print(sent)
Craig Robinson was denied a sentence.
At least so it seemed until Lara Croft came along
>>doc.sents
TypeError: object of type 'getset_descriptor' has no len()
```
Downside from what I understand is that cython generators don't have a __repr__ from what it seems so doc.sents and doc.noun_chunks raises an error - but the rest seemed to work fine

Would like to grab this opportunity to say thank you for publishing this code, very nice work :+1: 