### PR TITLE
fixed error when printing unicode

### DIFF
--- a/spacy/tests/print/test_print.py
+++ b/spacy/tests/print/test_print.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+def test_print_doc(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the coffee store')
+        print(doc)
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_repr_doc(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the coffee store')
+        print(repr(doc))
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_print_doc_unicode(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the café')
+        print(doc)
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_repr_doc_unicode(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the café')
+        print(repr(doc))
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_print_span(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the coffee store')[-3:]
+        print(doc)
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_repr_span(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the coffee store')[-3:]
+        print(repr(doc))
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_print_span_unicode(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the café')[-3:]
+        print(doc)
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_repr_span_unicode(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the café')[-3:]
+        print(repr(doc))
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_print_token(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the coffee store')[-1]
+        print(doc)
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_repr_token(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the coffee store')[-1]
+        print(repr(doc))
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_print_token_unicode(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the café')[-1]
+        print(doc)
+    except Exception:
+        pytest.fail("Printing failed")
+
+
+def test_repr_token_unicode(EN):
+    try:
+        doc = EN(u'I sat down for coffee at the café')[-1]
+        print(repr(doc))
+    except Exception:
+        pytest.fail("Printing failed")

--- a/spacy/tokens/doc.pyx
+++ b/spacy/tokens/doc.pyx
@@ -118,10 +118,10 @@ cdef class Doc:
         return u''.join([t.string for t in self])
 
     def __str__(self):
-        return u''.join([t.string for t in self])
+        return u''.join([t.string for t in self]).encode('utf-8')
 
     def __repr__(self):
-        return u''.join([t.string for t in self])
+        return u''.join([t.string for t in self]).encode('utf-8')
 
     def similarity(self, other):
         if self.vector_norm == 0 or other.vector_norm == 0:

--- a/spacy/tokens/spans.pyx
+++ b/spacy/tokens/spans.pyx
@@ -50,7 +50,7 @@ cdef class Span:
         text = self.text_with_ws
         if self[-1].whitespace_:
             text = text[:-1]
-        return text
+        return text.encode('utf-8')
 
     def __getitem__(self, object i):
         if isinstance(i, slice):

--- a/spacy/tokens/token.pyx
+++ b/spacy/tokens/token.pyx
@@ -41,10 +41,10 @@ cdef class Token:
         return self.string
 
     def __str__(self):
-        return self.string
+        return self.string.encode('utf-8')
 
     def __repr__(self):
-        return self.string
+        return self.string.encode('utf-8')
 
     cpdef bint check_flag(self, attr_id_t flag_id) except -1:
         return Lexeme.c_check_flag(self.c.lex, flag_id)


### PR DESCRIPTION
Corrected __str__ and __repr__ to return bytes - error was raised when printing strings that actually contained unicode characters - example: café . Added doctests to check printing for doc, span and token.