### PR TITLE
Add force flag to installation page.

### DIFF
--- a/website/src/jade/home/_installation.jade
+++ b/website/src/jade/home/_installation.jade
@@ -31,7 +31,7 @@ mixin Option(name, open)
 
     pre.language-bash: code
       | $ pip install spacy
-      | $ python -m spacy.en.download all
+      | $ python -m spacy.en.download --force all
 
   p
     | The download command fetches and installs about 400mb of data, for


### PR DESCRIPTION
Hi all,

I was just doing a clean install of spaCy via pip on a linux VM as well as on my local system, and in both cases, I found that the pip command would install some of the downloads right off the bat.  As a result, I kept getting an error saying the data was already installed when I ran 'python -m spacy.en.download all'!

To fix this for future installs, I went ahead and updated the website tutorial to default to the --force command, which will download everything right off the bat.  Hope this helps!  Spacy is great!

-Kevin Meurer