### PR TITLE
replace headers_workaround

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,30 +43,20 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip"
-
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "pip install --upgrade setuptools"
-  - "%CMD_IN_ENV% pip install cython fabric fabtools"
-  - "%CMD_IN_ENV% pip install -r requirements.txt"
+  - "%CMD_IN_ENV% python build.py prepare"
 
 build_script:
   # Build the compiled extension
-  - "%CMD_IN_ENV% python setup.py build_ext --inplace"
-  - ps: appveyor\download.ps1 
-  - "tar -xzf corpora/en/wordnet.tar.gz"
-  - "%CMD_IN_ENV% python bin/init_model.py en lang_data/ corpora/ spacy/en/data"
+  - "%CMD_IN_ENV% python build.py pip"
 
 
 test_script:
   # Run the project tests
-  - "pip install pytest"
-  - "%CMD_IN_ENV% py.test spacy/ -x"
+  - "%CMD_IN_ENV% python build.py test"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,7 +57,6 @@ build_script:
   # Build the compiled extension
   - "%CMD_IN_ENV% python build.py pip"
 
-
 test_script:
   # Run the project tests
   - "%CMD_IN_ENV% python build.py test"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,10 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user -U pip"
+
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,14 @@ os:
   - linux
 
 env:
-  - PIP_DATE=2015-10-01 PIP=1 INSTALL=0 DEVELOP=0
-  - PIP_DATE=2015-10-01 PIP=0 INSTALL=1 DEVELOP=0
-  - PIP_DATE=2015-10-01 PIP=0 INSTALL=0 DEVELOP=1
+  - PIP_DATE=2015-10-01 MODE=pip
+  - PIP_DATE=2015-10-01 MODE=setup-install
+  - PIP_DATE=2015-10-01 MODE=setup-develop
 
 install:
+  - pip install --disable-pip-version-check -U pip
   - python build.py prepare $PIP_DATE
 
 script:
-  - if [[ "$PIP" == "1" ]]; then
-      python build.py pip;
-    fi
-  - if [[ "$INSTALL" == "1" ]]; then
-      python build.py setup-install;
-    fi
-  - if [[ "$DEVELOP" == "1" ]]; then
-      python build.py setup-develop;
-    fi
+  - python build.py $MODE;
   - python build.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,28 +17,16 @@ env:
   - PIP_DATE=2015-10-01 PIP=0 INSTALL=0 DEVELOP=1
 
 install:
-  - pip install -U pip
-  - python pip-date.py $PIP_DATE pip setuptools wheel six
-  - pip install -r requirements.txt
-
-  - if [[ "$PIP" == "1" ]]; then
-      python setup.py sdist;
-      pip install dist/*;
-    fi
-
-  - if [[ "$INSTALL" == "1" ]]; then
-      python setup.py install;
-    fi
-
-  - if [[ "$DEVELOP" == "1" ]]; then
-      python setup.py develop;
-      pip install -e .;
-    fi
-
-  - pip install pytest
-  - pip list
+  - python build.py prepare $PIP_DATE
 
 script:
-  - mkdir tmp; cd tmp
-  - python -m spacy.en.download
-  - python -m pytest ../spacy/ -x --models --vectors --slow
+  - if [[ "$PIP" == "1" ]]; then
+      python build.py pip;
+    fi
+  - if [[ "$INSTALL" == "1" ]]; then
+      python build.py setup-install;
+    fi
+  - if [[ "$DEVELOP" == "1" ]]; then
+      python build.py setup-develop;
+    fi
+  - python build.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 recursive-include include *.h
-recursive-include spacy *.pyx *.pxd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include include *.h
+recursive-include spacy *.pyx *.pxd

--- a/README-MSVC.txt
+++ b/README-MSVC.txt
@@ -1,14 +1,14 @@
 Python 2.7 Windows build has been tested with the following toolchain:
 	- Python 2.7.10  :)
 	- Microsoft Visual C++ Compiler Package for Python 2.7		http://www.microsoft.com/en-us/download/details.aspx?id=44266
-	- C99 compliant stdint.h for MSVC				http://msinttypes.googlecode.com/svn/trunk/stdint.h
+	- C99 compliant stdint.h for MSVC				https://msinttypes.googlecode.com/svn/trunk/stdint.h
 	 (C99 complian stdint.h header which is not supplied with Microsoft Visual C++ compiler prior to MSVC 2010)
 
 Build steps:
 	- pip install --upgrade setuptools
 	- pip install cython fabric fabtools
 	- pip install -r requirements.txt
-	- python setup.py build_ext --inplace
+	- python pip install -e .
 
 If you are using traditional Microsoft SDK (v7.0 for Python 2.x or v7.1 for Python 3.x) consider run_with_env.cmd from appveyor folder (submodule) as a guideline for environment setup. 
 It can be also used as shell conviguration script for your build, install and run commands, i.e.: cmd /E:ON /V:ON /C run_with_env.cmd <your command> 

--- a/build.py
+++ b/build.py
@@ -23,7 +23,6 @@ install_mode = sys.argv[1]
 
 if install_mode == 'prepare':
     x('python pip-clear.py')
-    x('pip install --disable-pip-version-check -U pip setuptools')
 
     pip_date = len(sys.argv) > 2 and sys.argv[2]
     if pip_date:
@@ -50,10 +49,6 @@ elif install_mode == 'setup-install':
 
 
 elif install_mode == 'setup-develop':
-    x('python setup.py develop')
-    x('python pip-clear.py')
-
-    x('pip list')
     x('pip install -e .')
 
 

--- a/build.py
+++ b/build.py
@@ -65,7 +65,7 @@ elif install_mode == 'test':
         os.chdir('tmp')
 
         x('python -m spacy.en.download')
-        x('python -m pytest ../spacy/ --models --vectors --slow')
+        x('python -m pytest ../spacy/ -x --models --vectors --slow')
 
     finally:
         os.chdir(old)

--- a/pip-clear.py
+++ b/pip-clear.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+from pip.commands.uninstall import UninstallCommand
+from pip import get_installed_distributions
+
+
+packages = []
+for package in get_installed_distributions():
+    if package.location.endswith('dist-packages'):
+        continue
+    elif package.project_name in ('pip', 'setuptools'):
+        continue
+    packages.append(package.project_name)
+
+
+if packages:
+    pip = UninstallCommand()
+    options, args = pip.parse_args(packages)
+    options.yes = True
+
+    try:
+        pip.run(options, args)
+    except OSError as e:
+        if e.errno != 13:
+            raise e
+        print("You lack permissions to uninstall this package. Perhaps run with sudo? Exiting.")
+        exit(13)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 cymem == 1.30
 pathlib
-preshed == 0.44
+preshed == 0.45
 thinc == 4.0
 murmurhash == 0.26
 text-unidecode

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cython
 cymem == 1.30
 pathlib
 preshed == 0.45
-thinc == 4.0
+thinc == 4.1.0
 murmurhash == 0.26
 text-unidecode
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cymem == 1.30
 pathlib
 preshed == 0.44
 thinc == 4.0
-murmurhash == 0.25
+murmurhash == 0.26
 text-unidecode
 numpy
 plac

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cymem == 1.30
 pathlib
 preshed == 0.44
 thinc == 4.0
-murmurhash == 0.24
+murmurhash == 0.25
 text-unidecode
 numpy
 plac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cython
 cymem == 1.30
 pathlib
-preshed == 0.45
+preshed == 0.46.1
 thinc == 4.1.0
 murmurhash == 0.26
 text-unidecode

--- a/setup.py
+++ b/setup.py
@@ -270,7 +270,7 @@ def setup_package():
             license='MIT',
             ext_modules=ext_modules,
             install_requires=['numpy', 'murmurhash == 0.26', 'cymem == 1.30', 'preshed == 0.45',
-                              'thinc == 4.0.0', 'text_unidecode', 'plac', 'six',
+                              'thinc == 4.1.0', 'text_unidecode', 'plac', 'six',
                               'ujson', 'cloudpickle', 'sputnik == 0.6.2'],
             cmdclass = {
                 'build_ext': build_ext_subclass},

--- a/setup.py
+++ b/setup.py
@@ -261,6 +261,7 @@ def setup_package():
         setup(
             name='spacy',
             packages=PACKAGES,
+            package_data={'': ['*.pyx', '*.pxd']},
             description='Industrial-strength NLP',
             author='Matthew Honnibal',
             author_email='matt@spacy.io',

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ def setup_package():
             url='https://spacy.io',
             license='MIT',
             ext_modules=ext_modules,
-            install_requires=['numpy', 'murmurhash == 0.26', 'cymem == 1.30', 'preshed == 0.44',
+            install_requires=['numpy', 'murmurhash == 0.26', 'cymem == 1.30', 'preshed == 0.45',
                               'thinc == 4.0.0', 'text_unidecode', 'plac', 'six',
                               'ujson', 'cloudpickle', 'sputnik == 0.6.2'],
             cmdclass = {

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ def setup_package():
             url='https://spacy.io',
             license='MIT',
             ext_modules=ext_modules,
-            install_requires=['numpy', 'murmurhash == 0.26', 'cymem == 1.30', 'preshed == 0.45',
+            install_requires=['numpy', 'murmurhash == 0.26', 'cymem == 1.30', 'preshed == 0.46.1',
                               'thinc == 4.1.0', 'text_unidecode', 'plac', 'six',
                               'ujson', 'cloudpickle', 'sputnik == 0.6.2'],
             cmdclass = {

--- a/setup.py
+++ b/setup.py
@@ -269,7 +269,7 @@ def setup_package():
             url='https://spacy.io',
             license='MIT',
             ext_modules=ext_modules,
-            install_requires=['numpy', 'murmurhash == 0.25', 'cymem == 1.30', 'preshed == 0.44',
+            install_requires=['numpy', 'murmurhash == 0.26', 'cymem == 1.30', 'preshed == 0.44',
                               'thinc == 4.0.0', 'text_unidecode', 'plac', 'six',
                               'ujson', 'cloudpickle', 'sputnik == 0.6.2'],
             cmdclass = {

--- a/setup.py
+++ b/setup.py
@@ -206,9 +206,7 @@ def prepare_includes(path):
     copy_include(numpy.get_include(), include_dir, 'numpy')
 
     murmurhash = import_include('murmurhash')
-    copy_include(
-        os.path.join(os.path.dirname(murmurhash.__file__), 'headers'),
-        include_dir, 'murmurhash')
+    copy_include(murmurhash.get_include(), include_dir, 'murmurhash')
 
 
 def is_source_release(path):
@@ -270,7 +268,7 @@ def setup_package():
             url='https://spacy.io',
             license='MIT',
             ext_modules=ext_modules,
-            install_requires=['numpy', 'murmurhash == 0.24', 'cymem == 1.30', 'preshed == 0.44',
+            install_requires=['numpy', 'murmurhash == 0.25', 'cymem == 1.30', 'preshed == 0.44',
                               'thinc == 4.0.0', 'text_unidecode', 'plac', 'six',
                               'ujson', 'cloudpickle', 'sputnik == 0.6.2'],
             cmdclass = {

--- a/spacy/en/download.py
+++ b/spacy/en/download.py
@@ -17,8 +17,15 @@ def migrate(path):
 
 def link(package, path):
     if os.path.exists(path):
-        os.unlink(path)
-    os.symlink(package.dir_path('data'), path)
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.unlink(path)
+
+    if not hasattr(os, 'symlink'):  # not supported by win+py27
+        shutil.copytree(package.dir_path('data'), path)
+    else:
+        os.symlink(package.dir_path('data'), path)
 
 
 @plac.annotations(

--- a/venv.ps1
+++ b/venv.ps1
@@ -1,10 +1,10 @@
-$ErrorActionPreference = "Stop"
-
 param (
     [string]$python = $(throw "-python is required."),
     [string]$install_mode = $(throw "-install_mode is required."),
     [string]$pip_date
 )
+
+$ErrorActionPreference = "Stop"
  
 if(!(Test-Path -Path ".build"))
 {

--- a/venv.ps1
+++ b/venv.ps1
@@ -1,7 +1,7 @@
 param (
     [string]$python = $(throw "-python is required."),
     [string]$install_mode = $(throw "-install_mode is required."),
-    [string]$pip_date
+    [string]$pip_date,
     [string]$compiler
 )
 

--- a/venv.ps1
+++ b/venv.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 param (
     [string]$python = $(throw "-python is required."),
     [string]$install_mode = $(throw "-install_mode is required."),

--- a/venv.ps1
+++ b/venv.ps1
@@ -10,11 +10,10 @@ $ErrorActionPreference = "Stop"
 if(!(Test-Path -Path ".build"))
 {
     virtualenv .build --system-site-packages --python $python
-}
-
-if($compiler)
-{
-    "[build]`r`ncompiler=$compiler" | Out-File .\.build\Lib\distutils\distutils.cfg
+    if($compiler)
+    {
+        "[build]`r`ncompiler=$compiler" | Out-File -Encoding ascii .\.build\Lib\distutils\distutils.cfg
+    }
 }
 
 .build\Scripts\activate.ps1

--- a/venv.ps1
+++ b/venv.ps1
@@ -2,14 +2,21 @@ param (
     [string]$python = $(throw "-python is required."),
     [string]$install_mode = $(throw "-install_mode is required."),
     [string]$pip_date
+    [string]$compiler
 )
 
 $ErrorActionPreference = "Stop"
- 
+
 if(!(Test-Path -Path ".build"))
 {
-    virtualenv .build --python $python
+    virtualenv .build --system-site-packages --python $python
 }
+
+if($compiler)
+{
+    "[build]`r`ncompiler=$compiler" | Out-File .\.build\Lib\distutils\distutils.cfg
+}
+
 .build\Scripts\activate.ps1
 
 python build.py prepare $pip_date

--- a/venv.ps1
+++ b/venv.ps1
@@ -10,5 +10,7 @@ if(!(Test-Path -Path ".build"))
 }
 .build\Scripts\activate.ps1
 
-python build.py $install_mode $pip_date
+python build.py prepare $pip_date
+python build.py $install_mode
+python build.py test
 exit $LASTEXITCODE

--- a/venv.ps1
+++ b/venv.ps1
@@ -9,7 +9,15 @@ $ErrorActionPreference = "Stop"
 
 if(!(Test-Path -Path ".build"))
 {
-    virtualenv .build --system-site-packages --python $python
+    if($compiler -eq "mingw32")
+    {
+        virtualenv .build --system-site-packages --python $python
+    }
+    else
+    {
+        virtualenv .build --python $python
+    }
+
     if($compiler)
     {
         "[build]`r`ncompiler=$compiler" | Out-File -Encoding ascii .\.build\Lib\distutils\distutils.cfg

--- a/venv.sh
+++ b/venv.sh
@@ -5,7 +5,12 @@ if [ ! -d ".build" ]; then
     virtualenv .build --python $1
 fi
 
-. .build/bin/activate
+if [ -d ".build/bin" ]; then
+    source .build/bin/activate
+elif [ -d ".build/Scripts" ]; then
+    source .build/Scripts/activate
+fi
+
 python build.py prepare $3
 python build.py $2
 python build.py test

--- a/venv.sh
+++ b/venv.sh
@@ -6,4 +6,6 @@ if [ ! -d ".build" ]; then
 fi
 
 . .build/bin/activate
-python build.py $2 $3
+python build.py prepare $3
+python build.py $2
+python build.py test


### PR DESCRIPTION
This PR aims to fix the headers_workaround kludge:

- setup.py now follows closely numpy/scipy setup (should work with distutils and setuptools)
- setup.py doesn't import cython anymore (see bin/cythonize.py)
- headers for native dependencies (numpy, murmurhash) are now shipped as fallback
- add build.sh and tox for CI
- adds versioning mechanism (from numpy/scipy)

Building spaCy is now more clearly separated between 1) creating an sdist including cythonizing the source (typically performed by the maintainer) and 2) building/compiling the package (typically performed by the user).

Headers from numpy and murmurhash (copied from sdist build-time environment) are now shipped in the sdist (see package ./include dir) and used during installation in case they couldn't be found on the system.

Note that for creating an sdist or running tox you already need a python environment with all dependencies from requirements.txt, otherwise cython cannot build the sources. Take a look at build.sh for a sample setup.

Overall setup.py behaves now more standard-like: ```python setup.py develop``` or ```pip install -e .``` should work now. ```python setup.py build_ext --inplace``` is now deprecated.

The versioning automation is a leftover from numpy/scipy setup.py, but I thought it might serve as a good starting point. Obviously this part could be easily left out/replaced.

So far only limited testing took place: Mac/Linux 64 bit latest setuptools py27/py34

Sorry, I had to delete some files that were currently not cython-compiling (_nn, _theano, senses) or didn't run (test_de).