### PR TITLE
avoid writing to /tmp (not cross-platform compatible)

### DIFF
--- a/spacy/tests/serialize/test_io.py
+++ b/spacy/tests/serialize/test_io.py
@@ -4,6 +4,9 @@ from spacy.serialize.packer import Packer
 from spacy.attrs import ORTH, SPACY
 from spacy.tokens import Doc
 import math
+import tempfile
+import shutil
+import os
 
 
 @pytest.mark.models
@@ -11,17 +14,21 @@ def test_read_write(EN):
     doc1 = EN(u'This is a simple test. With a couple of sentences.')
     doc2 = EN(u'This is another test document.')
 
-    with open('/tmp/spacy_docs.bin', 'wb') as file_:
-        file_.write(doc1.to_bytes())
-        file_.write(doc2.to_bytes())
+    try:
+        tmp_dir = tempfile.mkdtemp()
+        with open(os.path.join(tmp_dir, 'spacy_docs.bin'), 'wb') as file_:
+            file_.write(doc1.to_bytes())
+            file_.write(doc2.to_bytes())
 
-    with open('/tmp/spacy_docs.bin', 'rb') as file_:
-        bytes1, bytes2 = Doc.read_bytes(file_)
-        r1 = Doc(EN.vocab).from_bytes(bytes1)
-        r2 = Doc(EN.vocab).from_bytes(bytes2)
+        with open(os.path.join(tmp_dir, 'spacy_docs.bin'), 'rb') as file_:
+            bytes1, bytes2 = Doc.read_bytes(file_)
+            r1 = Doc(EN.vocab).from_bytes(bytes1)
+            r2 = Doc(EN.vocab).from_bytes(bytes2)
 
-    assert r1.string == doc1.string
-    assert r2.string == doc2.string
+        assert r1.string == doc1.string
+        assert r2.string == doc2.string
+    finally:
+        shutil.rmtree(tmp_dir)
 
 
 @pytest.mark.models

--- a/spacy/tests/website/test_api.py
+++ b/spacy/tests/website/test_api.py
@@ -75,7 +75,7 @@ def test_count_by(nlp):
 @pytest.mark.models
 def test_read_bytes(nlp):
     from spacy.tokens.doc import Doc
-    loc = '/tmp/test_serialize.bin'
+    loc = 'test_serialize.bin'
     with open(loc, 'wb') as file_:
         file_.write(nlp(u'This is a document.').to_bytes())
         file_.write(nlp(u'This is another.').to_bytes())

--- a/spacy/tests/website/test_home.py
+++ b/spacy/tests/website/test_home.py
@@ -154,9 +154,9 @@ def test_efficient_binary_serialization(doc):
     from spacy.tokens.doc import Doc
 
     byte_string = doc.to_bytes()
-    open('/tmp/moby_dick.bin', 'wb').write(byte_string)
+    open('moby_dick.bin', 'wb').write(byte_string)
 
     nlp = spacy.en.English()
-    for byte_string in Doc.read_bytes(open('/tmp/moby_dick.bin', 'rb')):
+    for byte_string in Doc.read_bytes(open('moby_dick.bin', 'rb')):
        doc = Doc(nlp.vocab)
        doc.from_bytes(byte_string)


### PR DESCRIPTION
need a better solution for cleaning up after ```test_efficient_binary_serialization()```, but at least tests pass. See build error here: https://ci.spacy.io/builders/win64-0/builds/28/steps/shell_1/logs/stdio