### PR TITLE
integrate with sputnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,14 @@
 {
-    "name": "en_default",
-    "version": "0.100.0",
-    "description": "english default model",
+    "name": "en_test",
+    "version": "1.0.0",
+    "description": "english test model",
     "license": "public domain",
     "include": [
-        "deps/*",
-        "ner/*",
-        "pos/*",
-        "tokenizer/*",
-        "vocab/*",
-        "wordnet/*"
-    ],
-    "compatibility": {
-        "spacy": "==0.100.0"
-    }
+        ["deps", "*"],
+        ["ner", "*"],
+        ["pos", "*"],
+        ["tokenizer", "*"],
+        ["vocab", "*"],
+        ["wordnet", "*"]
+    ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ plac
 six
 ujson
 cloudpickle
-sputnik>=0.6.4,<0.7.0
+sputnik>=0.7.0,<0.8.0

--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,7 @@ def setup_package():
             ext_modules=ext_modules,
             install_requires=['numpy', 'murmurhash>=0.26,<0.27', 'cymem>=1.30,<1.31', 'preshed>=0.46.1,<0.47',
                               'thinc>=4.2.0,<4.3.0', 'text_unidecode', 'plac', 'six',
-                              'ujson', 'cloudpickle', 'sputnik>=0.6.4,<0.7.0'],
+                              'ujson', 'cloudpickle', 'sputnik>=0.7.0,<0.8.0'],
             cmdclass = {
                 'build_ext': build_ext_subclass},
         )

--- a/spacy/en/download.py
+++ b/spacy/en/download.py
@@ -3,7 +3,9 @@ import os
 import shutil
 
 import plac
-from sputnik import Sputnik
+import sputnik
+
+from .. import about
 
 
 def migrate(path):
@@ -35,23 +37,17 @@ def link(package, path):
     force=("Force overwrite", "flag", "f", bool),
 )
 def main(data_size='all', force=False):
-    # TODO read version from the same source as the setup
-    sputnik = Sputnik('spacy', '0.100.0', console=sys.stdout)
-
     path = os.path.dirname(os.path.abspath(__file__))
 
     data_path = os.path.abspath(os.path.join(path, '..', 'data'))
     if not os.path.isdir(data_path):
         os.mkdir(data_path)
 
-    command = sputnik.command(
-        data_path=data_path,
-        repository_url='https://index.spacy.io')
-
     if force:
-        command.purge()
+        sputnik.purge('spacy', about.short_version, data_path=data_path)
 
-    package = command.install('en_default')
+    package = sputnik.install('spacy', about.short_version, 'en_default==1.0.4',
+                              data_path=data_path)
 
     # FIXME clean up old-style packages
     migrate(path)

--- a/spacy/language.py
+++ b/spacy/language.py
@@ -20,7 +20,7 @@ from .syntax.ner import BiluoPushDown
 from .syntax.arc_eager import ArcEager
 
 from .attrs import TAG, DEP, ENT_IOB, ENT_TYPE, HEAD
-from .util import get_package, Package
+from .util import get_package
 
 
 class Language(object):
@@ -146,13 +146,13 @@ class Language(object):
 
     @classmethod
     def default_parser(cls, package, vocab):
-        data_dir = package.dir_path('deps', require=False)
+        data_dir = package.dir_path('deps')
         if data_dir and path.exists(data_dir):
             return Parser.from_dir(data_dir, vocab.strings, ArcEager)
 
     @classmethod
     def default_entity(cls, package, vocab):
-        data_dir = package.dir_path('ner', require=False)
+        data_dir = package.dir_path('ner')
         if data_dir and path.exists(data_dir):
             return Parser.from_dir(data_dir, vocab.strings, BiluoPushDown)
 
@@ -182,7 +182,7 @@ class Language(object):
              - Language(model='en_default ==1.0.0')
              - Language(model='en_default <1.1.0, data_dir='spacy/data')
         """
-        package = Package(data_dir)
+        package = get_package(model, data_path=data_dir)
         if load_vectors is not True:
             warn("load_vectors is deprecated", DeprecationWarning)
         if vocab in (None, True):

--- a/spacy/lemmatizer.py
+++ b/spacy/lemmatizer.py
@@ -8,13 +8,13 @@ except ImportError:
     import json
 
 from .parts_of_speech import NOUN, VERB, ADJ, PUNCT
-from .util import Package
+from .util import get_package
 
 
 class Lemmatizer(object):
     @classmethod
     def load(cls, pkg_or_str_or_file):
-        pkg = Package.create_or_return(pkg_or_str_or_file)
+        pkg = get_package(pkg_or_str_or_file)
         index = {}
         exc = {}
         for pos in ['adj', 'noun', 'verb']:

--- a/spacy/matcher.pyx
+++ b/spacy/matcher.pyx
@@ -21,7 +21,7 @@ from .tokens.doc cimport Doc
 from .vocab cimport Vocab
 
 from .attrs import FLAG61 as U_ENT
-from .util import Package
+from .util import get_package
 
 from .attrs import FLAG60 as B2_ENT
 from .attrs import FLAG59 as B3_ENT
@@ -171,7 +171,7 @@ cdef class Matcher:
 
     @classmethod
     def load(cls, pkg_or_str_or_file, Vocab vocab):
-        package = Package.create_or_return(pkg_or_str_or_file)
+        package = get_package(pkg_or_str_or_file)
         patterns = package.load_json(('vocab', 'gazetteer.json'))
         return cls(vocab, patterns)
 

--- a/spacy/tagger.pyx
+++ b/spacy/tagger.pyx
@@ -16,7 +16,7 @@ from .parts_of_speech cimport VERB, X, PUNCT, EOL, SPACE
 
 from .attrs cimport *
 
-from .util import Package
+from .util import get_package
 
  
 cpdef enum:
@@ -149,7 +149,7 @@ cdef class Tagger:
 
     @classmethod
     def load(cls, pkg_or_str_or_file, vocab):
-        pkg = Package.create_or_return(pkg_or_str_or_file)
+        pkg = get_package(pkg_or_str_or_file)
         # TODO: templates.json deprecated? not present in latest package
         templates = cls.default_templates()
         # templates = package.load_utf8(json.load,

--- a/spacy/tests/tagger/test_lemmatizer.py
+++ b/spacy/tests/tagger/test_lemmatizer.py
@@ -5,7 +5,7 @@ import io
 import pickle
 
 from spacy.lemmatizer import Lemmatizer, read_index, read_exc
-from spacy.util import get_package, Package
+from spacy.util import get_package
 
 import pytest
 

--- a/spacy/tokenizer.pyx
+++ b/spacy/tokenizer.pyx
@@ -17,7 +17,7 @@ cimport cython
 from . import util
 from .tokens.doc cimport Doc
 from .util import read_lang_data
-from .util import Package
+from .util import get_package
 
 
 cdef class Tokenizer:
@@ -43,7 +43,7 @@ cdef class Tokenizer:
 
     @classmethod
     def load(cls, pkg_or_str_or_file, Vocab vocab):
-        pkg = Package.create_or_return(pkg_or_str_or_file)
+        pkg = get_package(pkg_or_str_or_file)
         rules, prefix_re, suffix_re, infix_re = read_lang_data(pkg)
         prefix_re = re.compile(prefix_re)
         suffix_re = re.compile(suffix_re)

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -34,7 +34,7 @@ def get_package(value=None, data_path=None):
                            "model.")
     except CompatiblePackageNotFoundException as e:
         raise RuntimeError("Installed model is not compatible with spaCy "
-                           "version. Please run 'python -m spacy.en.download "
+                           "version. Please run 'python -m spacy.en.download' "
                            "--force' to install latest compatible model.")
 
 

--- a/spacy/util.py
+++ b/spacy/util.py
@@ -7,6 +7,7 @@ import os.path
 import sputnik
 from sputnik.dir_package import DirPackage
 from sputnik.package_stub import PackageStub
+from sputnik.package_list import PackageNotFoundException, CompatiblePackageNotFoundException
 
 from . import about
 from .attrs import TAG, HEAD, DEP, ENT_IOB, ENT_TYPE
@@ -22,8 +23,19 @@ def get_package(value=None, data_path=None):
     elif value is None and data_path is not None:
         return DirPackage(data_path)
 
-    return sputnik.package('spacy', about.short_version,
-                           value or 'en_default==1.0.4', data_path=data_path)
+    try:
+        return sputnik.package('spacy', about.short_version,
+                               value or 'en_default==1.0.4',
+                               data_path=data_path)
+
+    except PackageNotFoundException as e:
+        raise RuntimeError("Model not installed. Please run 'python -m "
+                           "spacy.en.download' to install latest compatible "
+                           "model.")
+    except CompatiblePackageNotFoundException as e:
+        raise RuntimeError("Installed model is not compatible with spaCy "
+                           "version. Please run 'python -m spacy.en.download "
+                           "--force' to install latest compatible model.")
 
 
 def normalize_slice(length, start, stop, step=None):

--- a/spacy/vocab.pyx
+++ b/spacy/vocab.pyx
@@ -19,7 +19,7 @@ from .orth cimport word_shape
 from .typedefs cimport attr_t
 from .cfile cimport CFile
 from .lemmatizer import Lemmatizer
-from .util import Package
+from .util import get_package
 
 from . import attrs
 from . import symbols
@@ -49,7 +49,7 @@ cdef class Vocab:
     '''
     @classmethod
     def load(cls, pkg_or_str_or_file, get_lex_attr=None):
-        package = Package.create_or_return(pkg_or_str_or_file)
+        package = get_package(pkg_or_str_or_file)
         tag_map = package.load_json(('vocab', 'tag_map.json'), default={})
 
         lemmatizer = Lemmatizer.load(package)


### PR DESCRIPTION
Sputnik now includes a new DirPackage class that offers a Package interface around a model directory. You can now instantiate spaCy as follows:

```
1) default
nlp = spacy.en.English()

2) model directory without dealing with packages (e.g., for development)
nlp = spacy.en.English('my/directory')
nlp = spacy.en.English(data_dir='my/directory')

3) with a different model
nlp = spacy.en.English('fr_default')

4) with a relocated package base
nlp = spacy.en.English(model='en_default', data_dir='new/root')

5) with an existing package
package = sputnik.package(<app_name>, <app_version>, 'my_model >=1.0.0', data_path='packages')
nlp = spacy.en.English(package)
```

Tokenizer/Tagger/Vocab/etc load() accepts string, directory or package
```